### PR TITLE
rename mobile to mobileed448

### DIFF
--- a/mobile/goldilocks.go
+++ b/mobile/goldilocks.go
@@ -1,4 +1,4 @@
-package mobile
+package mobileed448
 
 import (
 	"bytes"

--- a/mobile/goldilocks_test.go
+++ b/mobile/goldilocks_test.go
@@ -1,4 +1,4 @@
-package mobile
+package mobileed448
 
 import (
 	"fmt"

--- a/mobile/serialization.go
+++ b/mobile/serialization.go
@@ -1,4 +1,4 @@
-package mobile
+package mobileed448
 
 import (
 	"encoding/hex"


### PR DESCRIPTION
Rename `mobile` package to `mobileed448` to avoid conflict with other packages.